### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ services:
   - docker
 before_install:
 - npm install -g npm@2.13.5
+  - npm install -g nsp
 install: npm install
 script:
   - npm test
+  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 services:
   - docker
 before_install:
-- npm install -g npm@2.13.5
+  - npm install -g npm@2.13.5
   - npm install -g nsp
 install: npm install
 script:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Brian Leathem",
   "license": "MIT",
   "dependencies": {
-    "express": "4.13.4",
+    "express": "4.14.0",
     "fh-wfm-signature": "0.0.12",
     "lodash": "4.7.0"
   },


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-194
